### PR TITLE
Improve preview sampling performance

### DIFF
--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/ExpressionEditor.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/ExpressionEditor.cs
@@ -82,6 +82,11 @@ namespace Suzuryg.FaceEmo.Detail.AV3
         public void Dispose()
         {
             StopSampling();
+            if (_previewAvatar != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_previewAvatar);
+                _previewAvatar = null;
+            }
             Undo.undoRedoPerformed -= OnUndoRedoPerformed;
             _disposables.Dispose();
         }
@@ -129,12 +134,14 @@ namespace Suzuryg.FaceEmo.Detail.AV3
             var avatarRoot = _aV3Setting?.TargetAvatar?.gameObject;
             if (avatarRoot == null) { return; }
 
-            if (_previewAvatar != null) { UnityEngine.Object.DestroyImmediate(_previewAvatar); }
-            _previewAvatar = UnityEngine.Object.Instantiate(avatarRoot);
-            // FIXME: Unable to support the case that avatar's body shape balance is tuned by root object's scale. (Is it necessary to assume this case...?)
-            _previewAvatar.transform.localScale = Vector3.one;
-            _previewAvatar.SetActive(true);
-            _previewAvatar.hideFlags = HideFlags.HideAndDontSave;
+            if (_previewAvatar == null)
+            {
+                _previewAvatar = UnityEngine.Object.Instantiate(avatarRoot);
+                // FIXME: Unable to support the case that avatar's body shape balance is tuned by root object's scale. (Is it necessary to assume this case...?)
+                _previewAvatar.transform.localScale = Vector3.one;
+                _previewAvatar.SetActive(true);
+                _previewAvatar.hideFlags = HideFlags.HideAndDontSave;
+            }
 
             // Synthesize preview blend shape
             AnimationClip synthesized;
@@ -164,15 +171,7 @@ namespace Suzuryg.FaceEmo.Detail.AV3
 
         public void StopSampling()
         {
-            try
-            {
-                // Something
-            }
-            finally
-            {
-                if (_previewAvatar != null) { UnityEngine.Object.DestroyImmediate(_previewAvatar); }
-                AnimationMode.StopAnimationMode();
-            }
+            AnimationMode.StopAnimationMode();
         }
 
         public Vector3 GetAvatarViewPosition()

--- a/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/ExpressionEditor.cs
+++ b/Packages/jp.suzuryg.face-emo/Editor/Detail/AV3/ExpressionEditor.cs
@@ -159,7 +159,10 @@ namespace Suzuryg.FaceEmo.Detail.AV3
             // Sample
             if (synthesized != null)
             {
-                AnimationMode.StartAnimationMode();
+                if (!AnimationMode.InAnimationMode())
+                {
+                    AnimationMode.StartAnimationMode();
+                }
                 AnimationMode.BeginSampling();
                 AnimationMode.SampleAnimationClip(_previewAvatar, synthesized, synthesized.length);
                 AnimationMode.EndSampling();
@@ -171,7 +174,10 @@ namespace Suzuryg.FaceEmo.Detail.AV3
 
         public void StopSampling()
         {
-            AnimationMode.StopAnimationMode();
+            if (AnimationMode.InAnimationMode())
+            {
+                AnimationMode.StopAnimationMode();
+            }
         }
 
         public Vector3 GetAvatarViewPosition()
@@ -574,15 +580,8 @@ namespace Suzuryg.FaceEmo.Detail.AV3
 
         private void RenderPreviewClip()
         {
-            try
-            {
-                StartSampling();
-                _subWindowProvider.Provide<ExpressionPreviewWindow>()?.UpdateRenderCache();
-            }
-            finally
-            {
-                StopSampling();
-            }
+            StartSampling();
+            _subWindowProvider.Provide<ExpressionPreviewWindow>()?.UpdateRenderCache();
         }
 
         private void InitializePreviewClip()


### PR DESCRIPTION
## Summary
- reuse the preview avatar when sampling for slider updates
- stop destroying the preview avatar every time

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688224199c24832a8b699c9605ada5f8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **バグ修正**
  * プレビューアバターの不要な再生成や破棄を防止し、リソースのクリーンアップ処理を改善しました。
  * アニメーションモードの開始・停止処理の条件チェックを追加し、安定性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->